### PR TITLE
rhs-fastroping-comp fixes

### DIFF
--- a/optionals/compat_rhs_afrf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_afrf3/CfgVehicles.hpp
@@ -228,7 +228,7 @@ class CfgVehicles {
 
         class EventHandlers: EventHandlers {
             class RHS_EventHandlers: RHS_EventHandlers {
-                getOut = QUOTE(if !(_this getVariable [ARR_2(QUOTE(QEGVAR(fastroping,doorsLocked)),false)]) then {_this call rhs_fnc_mi8_doors});
+                getOut = QUOTE(if !((_this select 0) getVariable [ARR_2(QUOTE(QEGVAR(fastroping,doorsLocked)),false)]) then {_this call rhs_fnc_mi8_doors});
             };
         };
     };
@@ -250,7 +250,7 @@ class CfgVehicles {
 
         class EventHandlers: EventHandlers {
             class RHS_EventHandlers: RHS_EventHandlers {
-                getOut = QUOTE(if !(_this getVariable [ARR_2(QUOTE(QEGVAR(fastroping,doorsLocked)),false)]) then {_this call rhs_fnc_mi8_doors});
+                getOut = QUOTE(if !((_this select 0) getVariable [ARR_2(QUOTE(QEGVAR(fastroping,doorsLocked)),false)]) then {_this call rhs_fnc_mi8_doors});
             };
         };
     };

--- a/optionals/compat_rhs_afrf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_afrf3/CfgVehicles.hpp
@@ -208,6 +208,7 @@ class CfgVehicles {
     class Heli_Light_02_base_F: Helicopter_Base_H {};
     class RHS_Mi8_base : Heli_Light_02_base_F {
         EGVAR(refuel,fuelCapacity) = 3700;
+        EGVAR(fastroping,enabled) = 0;
         class EventHandlers: EventHandlers {
             class RHS_EventHandlers;
         };
@@ -258,10 +259,12 @@ class CfgVehicles {
     class Heli_Attack_02_base_F;
     class RHS_Ka52_base : Heli_Attack_02_base_F {
         EGVAR(refuel,fuelCapacity) = 1870;
+        EGVAR(fastroping,enabled) = 0;
     };
 
     class RHS_Mi24_base : Heli_Attack_02_base_F {
         EGVAR(refuel,fuelCapacity) = 1851;
+        EGVAR(fastroping,enabled) = 0;
     };
 
     class rhs_t80b : rhs_tank_base {

--- a/optionals/compat_rhs_usf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_usf3/CfgVehicles.hpp
@@ -87,16 +87,16 @@ class CfgVehicles {
         class UserActions: UserActions {
             class OpenCargoDoor;
             class CloseCargoDoor: OpenCargoDoor {
-                condition = QUOTE([ARR_2(this,'doorRB')] call FUNC(canCloseDoor));
+                condition = QUOTE([ARR_2(this,'doorRB')] call DFUNC(canCloseDoor));
             };
             class CloseCargoLDoor: OpenCargoDoor {
-                condition = QUOTE([ARR_2(this,'doorLB')] call FUNC(canCloseDoor));
+                condition = QUOTE([ARR_2(this,'doorLB')] call DFUNC(canCloseDoor));
             };
         };
 
         class EventHandlers: EventHandlers {
             class RHSUSF_EventHandlers: RHSUSF_EventHandlers {
-                getOut = QUOTE(if !(_this getVariable [ARR_2(QUOTE(QEGVAR(fastroping,doorsLocked)),false)]) then {_this call rhs_fnc_uh60_doors});
+                getOut = QUOTE(if !((_this select 0) getVariable [ARR_2(QUOTE(QEGVAR(fastroping,doorsLocked)),false)]) then {_this call rhs_fnc_uh60_doors});
             };
         };
     };
@@ -122,16 +122,15 @@ class CfgVehicles {
         class UserActions {
             class OpenCargoDoor;
             class CloseCargoDoor: OpenCargoDoor {
-                condition = QUOTE([ARR_2(this,'doorRB')] call FUNC(canCloseDoor));
+                condition = QUOTE([ARR_2(this,'doorRB')] call DFUNC(canCloseDoor));
             };
             class CloseCargoLDoor: OpenCargoDoor {
-                condition = QUOTE([ARR_2(this,'doorLB')] call FUNC(canCloseDoor));
+                condition = QUOTE([ARR_2(this,'doorLB')] call DFUNC(canCloseDoor));
             };
         };
-
         class EventHandlers: EventHandlers {
             class RHSUSF_EventHandlers {
-                getOut = QUOTE(if !(_this getVariable [ARR_2(QUOTE(QEGVAR(fastroping,doorsLocked)),false)]) then {_this call rhs_fnc_uh60_doors});
+                getOut = QUOTE(if !((_this select 0) getVariable [ARR_2(QUOTE(QEGVAR(fastroping,doorsLocked)),false)]) then {_this call rhs_fnc_uh60_doors});
             };
         };
 
@@ -164,7 +163,7 @@ class CfgVehicles {
         class UserActions {
             class OpenCargoDoor;
             class CloseCargoDoor: OpenCargoDoor {
-                condition = QUOTE([ARR_2(this,'ramp_anim')] call FUNC(canCloseDoor));
+                condition = QUOTE([ARR_2(this,'ramp_anim')] call DFUNC(canCloseDoor));
             };
         };
     };

--- a/optionals/compat_rhs_usf3/CfgVehicles.hpp
+++ b/optionals/compat_rhs_usf3/CfgVehicles.hpp
@@ -87,10 +87,10 @@ class CfgVehicles {
         class UserActions: UserActions {
             class OpenCargoDoor;
             class CloseCargoDoor: OpenCargoDoor {
-                condition = QUOTE([ARR_2(this,'doorRB')] call DFUNC(canCloseDoor));
+                condition = QUOTE([ARR_2(this,'doorRB')] call FUNC(canCloseDoor));
             };
             class CloseCargoLDoor: OpenCargoDoor {
-                condition = QUOTE([ARR_2(this,'doorLB')] call DFUNC(canCloseDoor));
+                condition = QUOTE([ARR_2(this,'doorLB')] call FUNC(canCloseDoor));
             };
         };
 
@@ -122,10 +122,10 @@ class CfgVehicles {
         class UserActions {
             class OpenCargoDoor;
             class CloseCargoDoor: OpenCargoDoor {
-                condition = QUOTE([ARR_2(this,'doorRB')] call DFUNC(canCloseDoor));
+                condition = QUOTE([ARR_2(this,'doorRB')] call FUNC(canCloseDoor));
             };
             class CloseCargoLDoor: OpenCargoDoor {
-                condition = QUOTE([ARR_2(this,'doorLB')] call DFUNC(canCloseDoor));
+                condition = QUOTE([ARR_2(this,'doorLB')] call FUNC(canCloseDoor));
             };
         };
         class EventHandlers: EventHandlers {
@@ -163,7 +163,7 @@ class CfgVehicles {
         class UserActions {
             class OpenCargoDoor;
             class CloseCargoDoor: OpenCargoDoor {
-                condition = QUOTE([ARR_2(this,'ramp_anim')] call DFUNC(canCloseDoor));
+                condition = QUOTE([ARR_2(this,'ramp_anim')] call FUNC(canCloseDoor));
             };
         };
     };


### PR DESCRIPTION
**When merged this pull request will:**
- fix error with trying to `getVariable` from array in `getOut` EH
- disable fastroping in rhs base classes to prevent using fastrope in not proper helicopters
